### PR TITLE
Upgrade dependencies to their latest versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   },
   "license": "BSD",
   "dependencies": {
-    "jshint": "~2.5.1",
-    "optimist": "~0.6.0",
-    "underscore": "~1.4.4"
+    "jshint": "~2.8.0",
+    "optimist": "~0.6.1",
+    "underscore": "~1.8.3"
   },
   "peerDependencies": {
     "coffee-script": ">= 1.6 <= 1.8.0"


### PR DESCRIPTION
@jonahkagan, these changes upgrade `coffee-jshint`'s normal `dependencies` to their latest versions, as per your request in #20.

The `coffee-script` version in `devDepencies` has not been touched to stay in line with the `peerDependencies` version range.

Note that more recent versions of `coffee-script` specify `"preferGlobal": true` in their `package.json`, resulting in an npm warning if you do try to upgrade it: 

```
npm WARN prefer global coffee-script@1.9.3 should be installed with -g
``` 

So ideally it should be removed altogether, but doing so will break your `Makefile`.