### PR TITLE
Alleviate upper bound on `coffee-script` peer dependency restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "underscore": "~1.8.3"
   },
   "peerDependencies": {
-    "coffee-script": ">= 1.6 <= 1.8.0"
+    "coffee-script": ">= 1.6 < 2"
   },
   "devDependencies": {
     "coffee-script": "~1.6.0"


### PR DESCRIPTION
@jonahkagan, this changes just the peer dep. As discussed earlier in [#21](/Clever/coffee-jshint/pull/21#issuecomment-117796098), the dev dep. on `coffee-script` is left as-is.